### PR TITLE
Simplify fold method

### DIFF
--- a/.idea/artifacts/remotedata_jvm_0_2.xml
+++ b/.idea/artifacts/remotedata_jvm_0_2.xml
@@ -1,0 +1,8 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="remotedata-jvm-0.2">
+    <output-path>$PROJECT_DIR$/remotedata/build/libs</output-path>
+    <root id="archive" name="remotedata-jvm-0.2.jar">
+      <element id="module-output" name="remotedata.remotedata.jvmMain" />
+    </root>
+  </artifact>
+</component>

--- a/remotedata-bom/build.gradle.kts
+++ b/remotedata-bom/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "remotedata"
-version = "0.1"
+version = "0.2"
 
 repositories {
     mavenCentral()

--- a/remotedata/build.gradle.kts
+++ b/remotedata/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "remotedata"
-version = "0.1"
+version = "0.2"
 
 repositories {
     mavenCentral()

--- a/remotedata/src/commonMain/kotlin/remotedata/RemoteData.kt
+++ b/remotedata/src/commonMain/kotlin/remotedata/RemoteData.kt
@@ -34,13 +34,13 @@ inline fun <E, D> RemoteData<E, D>.bind(
 inline fun <E, D, R> RemoteData<E, D>.fold(
     ifNotAsked: () -> R,
     ifLoading: () -> R,
-    ifFailure: (RemoteData.Failure<E>) -> R,
-    ifSuccess: (RemoteData.Success<D>) -> R,
+    ifFailure: (E) -> R,
+    ifSuccess: (D) -> R,
 ) = when (this) {
     RemoteData.NotAsked -> ifNotAsked()
     RemoteData.Loading -> ifLoading()
-    is RemoteData.Failure -> ifFailure(this)
-    is RemoteData.Success -> ifSuccess(this)
+    is RemoteData.Failure -> ifFailure(error)
+    is RemoteData.Success -> ifSuccess(data)
 }
 
 

--- a/remotedata/src/commonTest/kotlin/remotedata/RemoteDataTest.kt
+++ b/remotedata/src/commonTest/kotlin/remotedata/RemoteDataTest.kt
@@ -73,8 +73,8 @@ class RemoteDataTest {
     private fun <E, D, R> RemoteData<E, D>.foldOrFail(
         ifNotAsked: () -> R = { fail() },
         ifLoading: () -> R = { fail() },
-        ifFailure: (RemoteData.Failure<E>) -> R = { fail() },
-        ifSuccess: (RemoteData.Success<D>) -> R = { fail() },
+        ifFailure: (E) -> R = { fail() },
+        ifSuccess: (D) -> R = { fail() },
     ) =
         fold(
             ifNotAsked = ifNotAsked,


### PR DESCRIPTION
`RemoteData` type is known in the context of the specific `fold()` branches, so there's no point using a boxed argument.
